### PR TITLE
SBL 2nd Ed. - Series titles should be title case

### DIFF
--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -769,7 +769,7 @@
         <text macro="container-contributors"/>
       </group>
       <text macro="locators"/>
-      <text macro="collection-title" text-case="capitalize-first" prefix=". "/>
+      <text macro="collection-title" text-case="title" prefix=". "/>
       <text macro="issue"/>
       <text macro="locators-newspaper" prefix=", "/>
       <text macro="locators-journal"/>


### PR DESCRIPTION
Series titles are nearly always abbreviated (in both the note and bibliography, see #2 ), but when they're not, they should be title case, right?
