### PR TITLE
SBL 2nd Ed. - Series titles should always be short

### DIFF
--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -370,7 +370,7 @@
     </choose>
   </macro>
   <macro name="collection-title">
-    <text variable="collection-title"/>
+    <text variable="collection-title" form="short"/>
     <text variable="collection-number" prefix=" "/>
   </macro>
   <macro name="collection-title-note">


### PR DESCRIPTION
Like journal titles, series titles should always defer to the short form (in both the note and bibliography)
